### PR TITLE
New params update

### DIFF
--- a/app/consumer-democracy/ante/forbidden_proposals_ante.go
+++ b/app/consumer-democracy/ante/forbidden_proposals_ante.go
@@ -54,7 +54,6 @@ func (decorator ForbiddenProposalsDecorator) AnteHandle(ctx sdk.Context, tx sdk.
 				//Check if msg is Legacy paramchange proposal
 				sdkMsg, ok := message.GetCachedValue().(*govv1.MsgExecLegacyContent)
 				if !ok {
-					fmt.Println(message.TypeUrl)
 					if decorator.isModuleWhiteList(message.TypeUrl) {
 						m := message.GetCachedValue()
 						switch m.(type) {

--- a/app/consumer-democracy/ante/forbidden_proposals_ante.go
+++ b/app/consumer-democracy/ante/forbidden_proposals_ante.go
@@ -4,18 +4,40 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrorstypes "github.com/cosmos/cosmos-sdk/types/errors"
-	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	ccvgov "github.com/cosmos/interchain-security/x/ccv/democracy/governance"
 )
 
 type ForbiddenProposalsDecorator struct {
-	IsProposalWhitelisted func(govv1beta1.Content) bool
+	keeperMap                   map[string]interface{}
+	isLegacyProposalWhitelisted func(govv1beta1.Content) bool
+	isParamChangeWhitelisted    func(map[ccvgov.ParamChangeKey]struct{}) bool
+	isModuleWhiteList           func(string) bool
 }
 
-func NewForbiddenProposalsDecorator(whiteListFn func(govv1beta1.Content) bool) ForbiddenProposalsDecorator {
-	return ForbiddenProposalsDecorator{IsProposalWhitelisted: whiteListFn}
+func NewForbiddenProposalsDecorator(
+	whiteListFn func(govv1beta1.Content) bool,
+	isParamChangeWhitelisted func(map[ccvgov.ParamChangeKey]struct{}) bool,
+	keeperMap map[string]interface{},
+	isModuleWhiteList func(string) bool,
+) ForbiddenProposalsDecorator {
+	return ForbiddenProposalsDecorator{
+		isLegacyProposalWhitelisted: whiteListFn,
+		keeperMap:                   keeperMap,
+		isParamChangeWhitelisted:    isParamChangeWhitelisted,
+		isModuleWhiteList:           isModuleWhiteList,
+	}
 }
 
 func (decorator ForbiddenProposalsDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
@@ -25,19 +47,60 @@ func (decorator ForbiddenProposalsDecorator) AnteHandle(ctx sdk.Context, tx sdk.
 		submitProposalMgs, ok := msg.(*govv1.MsgSubmitProposal)
 		// if the message is MsgSubmitProposal, check if proposal is whitelisted
 		if ok {
-			message := submitProposalMgs.GetMessages()[0]
+			messages := submitProposalMgs.GetMessages()
+			var checkFlag bool = true
 
-			sdkMsg, ok := message.GetCachedValue().(*govv1.MsgExecLegacyContent)
-
-			if !ok {
-				return ctx, sdkerrorstypes.ErrInvalidType.Wrapf("expected %T, got %T", (*govv1.MsgExecLegacyContent)(nil), message.GetCachedValue())
+			for _, message := range messages {
+				//Check if msg is Legacy paramchange proposal
+				sdkMsg, ok := message.GetCachedValue().(*govv1.MsgExecLegacyContent)
+				if !ok {
+					fmt.Println(message.TypeUrl)
+					if decorator.isModuleWhiteList(message.TypeUrl) {
+						m := message.GetCachedValue()
+						switch m.(type) {
+						case *minttypes.MsgUpdateParams:
+							newParam := m.(*minttypes.MsgUpdateParams).Params
+							keeper := decorator.keeperMap[message.TypeUrl]
+							currentParam := keeper.(mintkeeper.Keeper).GetParams(ctx)
+							ccvgov.CheckIfParamKeyIsWhitelisted(&checkFlag, message.TypeUrl, currentParam, newParam, decorator.isParamChangeWhitelisted)
+						case *banktypes.MsgUpdateParams:
+							newParam := m.(*banktypes.MsgUpdateParams).Params
+							keeper := decorator.keeperMap[message.TypeUrl]
+							currentParam := keeper.(bankkeeper.Keeper).GetParams(ctx)
+							ccvgov.CheckIfParamKeyIsWhitelisted(&checkFlag, message.TypeUrl, currentParam, newParam, decorator.isParamChangeWhitelisted)
+						case *distrtypes.MsgUpdateParams:
+							newParam := m.(*distrtypes.MsgUpdateParams).Params
+							keeper := decorator.keeperMap[message.TypeUrl]
+							currentParam := keeper.(distrkeeper.Keeper).GetParams(ctx)
+							ccvgov.CheckIfParamKeyIsWhitelisted(&checkFlag, message.TypeUrl, currentParam, newParam, decorator.isParamChangeWhitelisted)
+						case *stakingtypes.MsgUpdateParams:
+							newParam := m.(*stakingtypes.MsgUpdateParams).Params
+							keeper := decorator.keeperMap[message.TypeUrl]
+							currentParam := keeper.(stakingkeeper.Keeper).GetParams(ctx)
+							ccvgov.CheckIfParamKeyIsWhitelisted(&checkFlag, message.TypeUrl, currentParam, newParam, decorator.isParamChangeWhitelisted)
+						case *govv1.MsgUpdateParams:
+							newParam := m.(*govv1.MsgUpdateParams).Params
+							keeper := decorator.keeperMap[message.TypeUrl]
+							currentParam := keeper.(govkeeper.Keeper).GetParams(ctx)
+							ccvgov.CheckIfParamKeyIsWhitelisted(&checkFlag, message.TypeUrl, currentParam, newParam, decorator.isParamChangeWhitelisted)
+						default:
+							checkFlag = false
+						}
+					} else {
+						checkFlag = false
+					}
+				} else {
+					content, err := govv1.LegacyContentFromMessage(sdkMsg)
+					if err != nil {
+						continue
+					}
+					if !decorator.isLegacyProposalWhitelisted(content) {
+						checkFlag = false
+					}
+				}
 			}
 
-			content, err := govv1.LegacyContentFromMessage(sdkMsg)
-			if err != nil {
-				return ctx, err
-			}
-			if !decorator.IsProposalWhitelisted(content) {
+			if !checkFlag {
 				return ctx, fmt.Errorf("tx contains unsupported proposal message types at height %d", currHeight)
 			}
 		}

--- a/app/consumer-democracy/ante/forbidden_proposals_ante_test.go
+++ b/app/consumer-democracy/ante/forbidden_proposals_ante_test.go
@@ -3,19 +3,105 @@ package ante_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	app "github.com/cosmos/interchain-security/app/consumer-democracy"
 	"github.com/cosmos/interchain-security/app/consumer-democracy/ante"
 	"github.com/stretchr/testify/require"
+
+	ibctesting "github.com/cosmos/interchain-security/legacy_ibc_testing/testing"
+	icstestingutils "github.com/cosmos/interchain-security/testutil/ibc_testing"
+	testutil "github.com/cosmos/interchain-security/testutil/integration"
 )
+
+type DemocSetupCallback func(t *testing.T) (
+	coord *ibctesting.Coordinator,
+	consumerChain *ibctesting.TestChain,
+	consumerApp testutil.DemocConsumerApp,
+)
+
+type ConsumerDemocracyTestSuite struct {
+	suite.Suite
+	coordinator   *ibctesting.Coordinator
+	consumerChain *ibctesting.TestChain
+	consumerApp   testutil.DemocConsumerApp
+	setupCallback DemocSetupCallback
+}
+
+// NewCCVTestSuite returns a new instance of ConsumerDemocracyTestSuite,
+// ready to be tested against using suite.Run().
+func NewConsumerDemocracyTestSuite[T testutil.DemocConsumerApp](
+	democConsumerAppIniter ibctesting.AppIniter,
+) *ConsumerDemocracyTestSuite {
+	democSuite := new(ConsumerDemocracyTestSuite)
+
+	democSuite.setupCallback = func(t *testing.T) (
+		*ibctesting.Coordinator,
+		*ibctesting.TestChain,
+		testutil.DemocConsumerApp,
+	) {
+		t.Helper()
+		// Instantiate the test coordinator
+		coordinator := ibctesting.NewCoordinator(t, 0)
+
+		// Add single democracy consumer to coordinator, store returned test chain and app.
+		democConsumer, democConsumerApp := icstestingutils.AddDemocracyConsumer[T](
+			t, coordinator, democConsumerAppIniter)
+
+		// Pass variables to suite.
+		return coordinator, democConsumer, democConsumerApp
+	}
+	return democSuite
+}
+
+func (suite *ConsumerDemocracyTestSuite) SetupTest() {
+	// Instantiate new test utils using callback
+	suite.coordinator, suite.consumerChain,
+		suite.consumerApp = suite.setupCallback(suite.T())
+}
+
+func setup(t *testing.T) *ConsumerDemocracyTestSuite {
+	t.Helper()
+	suite := NewConsumerDemocracyTestSuite[*app.App](
+		icstestingutils.DemocracyConsumerAppIniter)
+	suite.SetT(t)
+	suite.SetupTest()
+
+	return suite
+}
 
 func TestForbiddenProposalsDecorator(t *testing.T) {
 	txCfg := app.MakeTestEncodingConfig().TxConfig
+
+	suite := setup(t)
+
+	accountKeeper := suite.consumerApp.GetTestAccountKeeper()
+	mintKeeper := suite.consumerApp.GetTestMintKeeper()
+
+	newAuthParamValue := uint64(128)
+	newMintParamValue := sdk.NewDecWithPrec(1, 1) // "0.100000000000000000"
+
+	// Mint MsgUpdateParams
+	mintParams := mintKeeper.GetParams(suite.consumerChain.GetContext())
+	mintParams.InflationMax = newMintParamValue
+	msg_1 := &minttypes.MsgUpdateParams{
+		Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		Params:    mintParams,
+	}
+	// Auth MsgUpdateParams
+	authParams := accountKeeper.GetParams(suite.consumerChain.GetContext())
+	authParams.MaxMemoCharacters = newAuthParamValue
+	msg_2 := &authtypes.MsgUpdateParams{
+		Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		Params:    authParams,
+	}
 
 	testCases := []struct {
 		name      string
@@ -24,10 +110,10 @@ func TestForbiddenProposalsDecorator(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			name: "Allowed param change",
-			ctx:  sdk.Context{},
+			name: "Allowed legacy param change",
+			ctx:  suite.consumerChain.GetContext(),
 			msgs: []sdk.Msg{
-				newParamChangeProposalMsg([]proposal.ParamChange{
+				newLegacyParamChangeProposalMsg([]proposal.ParamChange{
 					// only subspace and key are relevant for testing
 					{Subspace: banktypes.ModuleName, Key: "SendEnabled", Value: ""},
 				}),
@@ -35,10 +121,37 @@ func TestForbiddenProposalsDecorator(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "Forbidden param change",
-			ctx:  sdk.Context{},
+			name: "Allowed param change",
+			ctx:  suite.consumerChain.GetContext(),
 			msgs: []sdk.Msg{
-				newParamChangeProposalMsg([]proposal.ParamChange{
+				newParamChangeProposalMsg([]sdk.Msg{msg_1}),
+			},
+			expectErr: false,
+		},
+		{
+			name: "Forbidden legacy param change",
+			ctx:  suite.consumerChain.GetContext(),
+			msgs: []sdk.Msg{
+				newLegacyParamChangeProposalMsg([]proposal.ParamChange{
+					{Subspace: authtypes.ModuleName, Key: "MaxMemoCharacters", Value: ""},
+				}),
+			},
+			expectErr: true,
+		},
+		{
+			name: "Forbidden param change",
+			ctx:  suite.consumerChain.GetContext(),
+			msgs: []sdk.Msg{
+				newParamChangeProposalMsg([]sdk.Msg{msg_2}),
+			},
+			expectErr: true,
+		},
+		{
+			name: "Allowed and forbidden legacy param changes in the same msg",
+			ctx:  suite.consumerChain.GetContext(),
+			msgs: []sdk.Msg{
+				newLegacyParamChangeProposalMsg([]proposal.ParamChange{
+					{Subspace: banktypes.ModuleName, Key: "SendEnabled", Value: ""},
 					{Subspace: authtypes.ModuleName, Key: "MaxMemoCharacters", Value: ""},
 				}),
 			},
@@ -46,23 +159,29 @@ func TestForbiddenProposalsDecorator(t *testing.T) {
 		},
 		{
 			name: "Allowed and forbidden param changes in the same msg",
-			ctx:  sdk.Context{},
+			ctx:  suite.consumerChain.GetContext(),
 			msgs: []sdk.Msg{
-				newParamChangeProposalMsg([]proposal.ParamChange{
-					{Subspace: banktypes.ModuleName, Key: "SendEnabled", Value: ""},
-					{Subspace: authtypes.ModuleName, Key: "MaxMemoCharacters", Value: ""},
-				}),
+				newParamChangeProposalMsg([]sdk.Msg{msg_1, msg_2}),
+			},
+			expectErr: true,
+		},
+		{
+			name: "Allowed and forbidden legacy param changes in different msg",
+			ctx:  suite.consumerChain.GetContext(),
+			msgs: []sdk.Msg{
+				newParamChangeProposalMsg([]sdk.Msg{msg_1}),
+				newParamChangeProposalMsg([]sdk.Msg{msg_2}),
 			},
 			expectErr: true,
 		},
 		{
 			name: "Allowed and forbidden param changes in different msg",
-			ctx:  sdk.Context{},
+			ctx:  suite.consumerChain.GetContext(),
 			msgs: []sdk.Msg{
-				newParamChangeProposalMsg([]proposal.ParamChange{
+				newLegacyParamChangeProposalMsg([]proposal.ParamChange{
 					{Subspace: banktypes.ModuleName, Key: "SendEnabled", Value: ""},
 				}),
-				newParamChangeProposalMsg([]proposal.ParamChange{
+				newLegacyParamChangeProposalMsg([]proposal.ParamChange{
 					{Subspace: authtypes.ModuleName, Key: "MaxMemoCharacters", Value: ""},
 				}),
 			},
@@ -74,7 +193,7 @@ func TestForbiddenProposalsDecorator(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			handler := ante.NewForbiddenProposalsDecorator(app.IsProposalWhitelisted)
+			handler := ante.NewForbiddenProposalsDecorator(app.IsProposalWhitelisted, app.IsParamChangeWhitelisted, suite.consumerApp.GetKeeperMap(), app.IsModuleWhiteList)
 
 			txBuilder := txCfg.NewTxBuilder()
 			require.NoError(t, txBuilder.SetMsgs(tc.msgs...))
@@ -90,12 +209,17 @@ func TestForbiddenProposalsDecorator(t *testing.T) {
 	}
 }
 
-func newParamChangeProposalMsg(changes []proposal.ParamChange) *govv1.MsgSubmitProposal {
+func newLegacyParamChangeProposalMsg(changes []proposal.ParamChange) *govv1.MsgSubmitProposal {
 	paramChange := proposal.ParameterChangeProposal{Changes: changes}
 	msgContent, err := govv1.NewLegacyContent(&paramChange, authtypes.NewModuleAddress(govtypes.ModuleName).String())
 	if err != nil {
 		return nil
 	}
 	msg, _ := govv1.NewMsgSubmitProposal([]sdk.Msg{msgContent}, sdk.NewCoins(), sdk.AccAddress{}.String(), "", "", "")
+	return msg
+}
+
+func newParamChangeProposalMsg(msgs []sdk.Msg) *govv1.MsgSubmitProposal {
+	msg, _ := govv1.NewMsgSubmitProposal(msgs, sdk.NewCoins(), sdk.AccAddress{}.String(), "", "", "")
 	return msg
 }

--- a/app/consumer-democracy/ante_handler.go
+++ b/app/consumer-democracy/ante_handler.go
@@ -21,7 +21,7 @@ type HandlerOptions struct {
 	ConsumerKeeper ibcconsumerkeeper.Keeper
 }
 
-func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
+func NewAnteHandler(options HandlerOptions, keeperMap map[string]interface{}) (sdk.AnteHandler, error) {
 	if options.AccountKeeper == nil {
 		return nil, sdkerrors.Wrap(sdkerrorstypes.ErrLogic, "account keeper is required for AnteHandler")
 	}
@@ -42,7 +42,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewExtensionOptionsDecorator(nil),
 		consumerante.NewMsgFilterDecorator(options.ConsumerKeeper),
 		consumerante.NewDisabledModulesDecorator("/cosmos.evidence", "/cosmos.slashing"),
-		democracyante.NewForbiddenProposalsDecorator(IsProposalWhitelisted),
+		democracyante.NewForbiddenProposalsDecorator(IsProposalWhitelisted, IsParamChangeWhitelisted, keeperMap, IsModuleWhiteList),
 		ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, nil),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),

--- a/app/consumer-democracy/app.go
+++ b/app/consumer-democracy/app.go
@@ -504,6 +504,14 @@ func New(
 
 	skipGenesisInvariants := cast.ToBool(appOpts.Get(crisis.FlagSkipGenesisInvariants))
 
+	keeperMap := map[string]interface{}{
+		"/cosmos.gov.v1.MsgUpdateParams":               app.GovKeeper,
+		"/cosmos.bank.v1beta1.MsgUpdateParams":         app.BankKeeper,
+		"/cosmos.staking.v1beta1.MsgUpdateParams":      &app.StakingKeeper,
+		"/cosmos.distribution.v1beta1.MsgUpdateParams": app.DistrKeeper,
+		"/cosmos.mint.v1beta1.MsgUpdateParams":         app.MintKeeper,
+	}
+
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.
 	app.MM = module.NewManager(
@@ -513,7 +521,7 @@ func New(
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper, false),
 		crisis.NewAppModule(&app.CrisisKeeper, skipGenesisInvariants, app.GetSubspace(crisistypes.ModuleName)),
 		feegrantmodule.NewAppModule(appCodec, app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),
-		ccvgov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper, IsProposalWhitelisted, app.GetSubspace(govtypes.ModuleName)),
+		ccvgov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper, IsProposalWhitelisted, IsParamChangeWhitelisted, app.GetSubspace(govtypes.ModuleName), keeperMap, IsModuleWhiteList),
 		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper, nil, app.GetSubspace(minttypes.ModuleName)),
 		slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.ConsumerKeeper, app.GetSubspace(slashingtypes.ModuleName)),
 		ccvdistr.NewAppModule(appCodec, app.DistrKeeper, app.AccountKeeper, app.BankKeeper, *app.StakingKeeper, authtypes.FeeCollectorName, app.GetSubspace(distrtypes.ModuleName)),
@@ -615,7 +623,7 @@ func New(
 		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper, app.GetSubspace(banktypes.ModuleName)),
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper, false),
 		feegrantmodule.NewAppModule(appCodec, app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),
-		ccvgov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper, IsProposalWhitelisted, app.GetSubspace(govtypes.ModuleName)),
+		ccvgov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper, IsProposalWhitelisted, IsParamChangeWhitelisted, app.GetSubspace(govtypes.ModuleName), keeperMap, IsModuleWhiteList),
 		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper, nil, app.GetSubspace(minttypes.ModuleName)),
 		ccvstaking.NewAppModule(appCodec, *app.StakingKeeper, app.AccountKeeper, app.BankKeeper, app.GetSubspace(stakingtypes.ModuleName)),
 		ccvdistr.NewAppModule(appCodec, app.DistrKeeper, app.AccountKeeper, app.BankKeeper, *app.StakingKeeper, authtypes.FeeCollectorName, app.GetSubspace(distrtypes.ModuleName)),

--- a/app/consumer-democracy/app.go
+++ b/app/consumer-democracy/app.go
@@ -893,6 +893,11 @@ func (app *App) GetTestGovKeeper() testutil.TestGovKeeper {
 	return app.GovKeeper
 }
 
+// GetTestAuthKeeper implements the ConsumerApp interface.
+func (app *App) GetTestAuthKeeper() testutil.TestAccountKeeper {
+	return app.AccountKeeper
+}
+
 // TestingApp functions
 
 // GetBaseApp implements the TestingApp interface.

--- a/app/consumer-democracy/app.go
+++ b/app/consumer-democracy/app.go
@@ -229,6 +229,9 @@ type App struct { // nolint: golint
 	// simulation manager
 	sm           *module.SimulationManager
 	configurator module.Configurator
+
+	// whitelist module's keeper map
+	KeeperMap map[string]interface{}
 }
 
 func init() {
@@ -512,6 +515,8 @@ func New(
 		"/cosmos.mint.v1beta1.MsgUpdateParams":         app.MintKeeper,
 	}
 
+	app.KeeperMap = keeperMap
+
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.
 	app.MM = module.NewManager(
@@ -653,6 +658,7 @@ func New(
 			IBCKeeper:      app.IBCKeeper,
 			ConsumerKeeper: app.ConsumerKeeper,
 		},
+		keeperMap,
 	)
 	if err != nil {
 		panic(fmt.Errorf("failed to create AnteHandler: %s", err))
@@ -893,11 +899,6 @@ func (app *App) GetTestGovKeeper() testutil.TestGovKeeper {
 	return app.GovKeeper
 }
 
-// GetTestAuthKeeper implements the ConsumerApp interface.
-func (app *App) GetTestAuthKeeper() testutil.TestAccountKeeper {
-	return app.AccountKeeper
-}
-
 // TestingApp functions
 
 // GetBaseApp implements the TestingApp interface.
@@ -923,6 +924,11 @@ func (app *App) GetScopedIBCKeeper() capabilitykeeper.ScopedKeeper {
 // GetTxConfig implements the TestingApp interface.
 func (app *App) GetTxConfig() client.TxConfig {
 	return MakeTestEncodingConfig().TxConfig
+}
+
+// GetKeeperMap return keeper map
+func (app *App) GetKeeperMap() map[string]interface{} {
+	return app.KeeperMap
 }
 
 // RegisterAPIRoutes registers all application module routes with the provided

--- a/app/consumer-democracy/proposals_whitelisting.go
+++ b/app/consumer-democracy/proposals_whitelisting.go
@@ -3,9 +3,7 @@ package app
 import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
-	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
@@ -23,7 +21,7 @@ func IsProposalWhitelisted(content v1beta1.Content) bool {
 
 func isParamChangeWhitelisted(paramChanges []proposal.ParamChange) bool {
 	for _, paramChange := range paramChanges {
-		_, found := WhitelistedParams[paramChangeKey{Subspace: paramChange.Subspace, Key: paramChange.Key}]
+		_, found := LegacyWhitelistedParams[legacyParamChangeKey{Subspace: paramChange.Subspace, Key: paramChange.Key}]
 		if !found {
 			return false
 		}
@@ -31,37 +29,45 @@ func isParamChangeWhitelisted(paramChanges []proposal.ParamChange) bool {
 	return true
 }
 
-type paramChangeKey struct {
+type legacyParamChangeKey struct {
 	Subspace, Key string
+}
+
+var LegacyWhitelistedParams = map[legacyParamChangeKey]struct{}{
+	// ibc transfer
+	{Subspace: ibctransfertypes.ModuleName, Key: "SendEnabled"}:    {},
+	{Subspace: ibctransfertypes.ModuleName, Key: "ReceiveEnabled"}: {},
+	// add interchain account params(HostEnabled, AllowedMessages) once the module is added to the consumer app
+}
+
+type paramChangeKey struct {
+	MsgType, Key string
 }
 
 var WhitelistedParams = map[paramChangeKey]struct{}{
 	// bank
-	{Subspace: banktypes.ModuleName, Key: "SendEnabled"}: {},
+	{MsgType: banktypes.TypeMsgUpdateParams, Key: "SendEnabled"}: {},
 	// governance
-	{Subspace: govtypes.ModuleName, Key: "depositparams"}: {}, // min_deposit, max_deposit_period
-	{Subspace: govtypes.ModuleName, Key: "votingparams"}:  {}, // voting_period
-	{Subspace: govtypes.ModuleName, Key: "tallyparams"}:   {}, // quorum,threshold,veto_threshold
+	{MsgType: "cosmos.gov.v1.MsgUpdateParams", Key: "depositparams"}: {}, // min_deposit, max_deposit_period
+	{MsgType: "cosmos.gov.v1.MsgUpdateParams", Key: "votingparams"}:  {}, // voting_period
+	{MsgType: "cosmos.gov.v1.MsgUpdateParams", Key: "tallyparams"}:   {}, // quorum,threshold,veto_threshold
 	// staking
-	{Subspace: stakingtypes.ModuleName, Key: "UnbondingTime"}:     {},
-	{Subspace: stakingtypes.ModuleName, Key: "MaxValidators"}:     {},
-	{Subspace: stakingtypes.ModuleName, Key: "MaxEntries"}:        {},
-	{Subspace: stakingtypes.ModuleName, Key: "HistoricalEntries"}: {},
-	{Subspace: stakingtypes.ModuleName, Key: "BondDenom"}:         {},
+	{MsgType: stakingtypes.TypeMsgUpdateParams, Key: "UnbondingTime"}:     {},
+	{MsgType: stakingtypes.TypeMsgUpdateParams, Key: "MaxValidators"}:     {},
+	{MsgType: stakingtypes.TypeMsgUpdateParams, Key: "MaxEntries"}:        {},
+	{MsgType: stakingtypes.TypeMsgUpdateParams, Key: "HistoricalEntries"}: {},
+	{MsgType: stakingtypes.TypeMsgUpdateParams, Key: "BondDenom"}:         {},
 	// distribution
-	{Subspace: distrtypes.ModuleName, Key: "communitytax"}: {},
+	{MsgType: distrtypes.TypeMsgUpdateParams, Key: "communitytax"}: {},
 	// {Subspace: distrtypes.ModuleName, Key: "baseproposerreward"}:  {},   depricated key
 	// {Subspace: distrtypes.ModuleName, Key: "bonusproposerreward"}: {},   depricated key
-	{Subspace: distrtypes.ModuleName, Key: "withdrawaddrenabled"}: {},
+	{MsgType: distrtypes.TypeMsgUpdateParams, Key: "withdrawaddrenabled"}: {},
 	// mint
-	{Subspace: minttypes.ModuleName, Key: "MintDenom"}:           {},
-	{Subspace: minttypes.ModuleName, Key: "InflationRateChange"}: {},
-	{Subspace: minttypes.ModuleName, Key: "InflationMax"}:        {},
-	{Subspace: minttypes.ModuleName, Key: "InflationMin"}:        {},
-	{Subspace: minttypes.ModuleName, Key: "GoalBonded"}:          {},
-	{Subspace: minttypes.ModuleName, Key: "BlocksPerYear"}:       {},
-	// ibc transfer
-	{Subspace: ibctransfertypes.ModuleName, Key: "SendEnabled"}:    {},
-	{Subspace: ibctransfertypes.ModuleName, Key: "ReceiveEnabled"}: {},
+	{MsgType: "cosmos.mint.v1beta1.MsgUpdateParams", Key: "MintDenom"}:           {},
+	{MsgType: "cosmos.mint.v1beta1.MsgUpdateParams", Key: "InflationRateChange"}: {},
+	{MsgType: "cosmos.mint.v1beta1.MsgUpdateParams", Key: "InflationMax"}:        {},
+	{MsgType: "cosmos.mint.v1beta1.MsgUpdateParams", Key: "InflationMin"}:        {},
+	{MsgType: "cosmos.mint.v1beta1.MsgUpdateParams", Key: "GoalBonded"}:          {},
+	{MsgType: "cosmos.mint.v1beta1.MsgUpdateParams", Key: "BlocksPerYear"}:       {},
 	// add interchain account params(HostEnabled, AllowedMessages) once the module is added to the consumer app
 }

--- a/app/consumer-democracy/proposals_whitelisting.go
+++ b/app/consumer-democracy/proposals_whitelisting.go
@@ -1,8 +1,13 @@
 package app
 
 import (
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/x/params/types/proposal"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	ccvgov "github.com/cosmos/interchain-security/x/ccv/democracy/governance"
 )
@@ -42,6 +47,29 @@ type legacyParamChangeKey struct {
 }
 
 var LegacyWhitelistedParams = map[legacyParamChangeKey]struct{}{
+	{Subspace: banktypes.ModuleName, Key: "SendEnabled"}: {},
+	// governance
+	{Subspace: govtypes.ModuleName, Key: "depositparams"}: {}, // min_deposit, max_deposit_period
+	{Subspace: govtypes.ModuleName, Key: "votingparams"}:  {}, // voting_period
+	{Subspace: govtypes.ModuleName, Key: "tallyparams"}:   {}, // quorum,threshold,veto_threshold
+	// staking
+	{Subspace: stakingtypes.ModuleName, Key: "UnbondingTime"}:     {},
+	{Subspace: stakingtypes.ModuleName, Key: "MaxValidators"}:     {},
+	{Subspace: stakingtypes.ModuleName, Key: "MaxEntries"}:        {},
+	{Subspace: stakingtypes.ModuleName, Key: "HistoricalEntries"}: {},
+	{Subspace: stakingtypes.ModuleName, Key: "BondDenom"}:         {},
+	// distribution
+	{Subspace: distrtypes.ModuleName, Key: "communitytax"}: {},
+	// {Subspace: distrtypes.ModuleName, Key: "baseproposerreward"}:  {},   depricated key
+	// {Subspace: distrtypes.ModuleName, Key: "bonusproposerreward"}: {},   depricated key
+	{Subspace: distrtypes.ModuleName, Key: "withdrawaddrenabled"}: {},
+	// mint
+	{Subspace: minttypes.ModuleName, Key: "MintDenom"}:           {},
+	{Subspace: minttypes.ModuleName, Key: "InflationRateChange"}: {},
+	{Subspace: minttypes.ModuleName, Key: "InflationMax"}:        {},
+	{Subspace: minttypes.ModuleName, Key: "InflationMin"}:        {},
+	{Subspace: minttypes.ModuleName, Key: "GoalBonded"}:          {},
+	{Subspace: minttypes.ModuleName, Key: "BlocksPerYear"}:       {},
 	// ibc transfer
 	{Subspace: ibctransfertypes.ModuleName, Key: "SendEnabled"}:    {},
 	{Subspace: ibctransfertypes.ModuleName, Key: "ReceiveEnabled"}: {},
@@ -62,9 +90,7 @@ var WhitelistedParams = map[ccvgov.ParamChangeKey]struct{}{
 	{MsgType: "/cosmos.staking.v1beta1.MsgUpdateParams", Key: "HistoricalEntries"}: {},
 	{MsgType: "/cosmos.staking.v1beta1.MsgUpdateParams", Key: "BondDenom"}:         {},
 	// distribution
-	{MsgType: "/cosmos.distribution.v1beta1.MsgUpdateParams", Key: "communitytax"}: {},
-	// {Subspace: distrtypes.ModuleName, Key: "baseproposerreward"}:  {},   depricated key
-	// {Subspace: distrtypes.ModuleName, Key: "bonusproposerreward"}: {},   depricated key
+	{MsgType: "/cosmos.distribution.v1beta1.MsgUpdateParams", Key: "communitytax"}:        {},
 	{MsgType: "/cosmos.distribution.v1beta1.MsgUpdateParams", Key: "withdrawaddrenabled"}: {},
 	// mint
 	{MsgType: "/cosmos.mint.v1beta1.MsgUpdateParams", Key: "MintDenom"}:           {},

--- a/app/consumer-democracy/proposals_whitelisting.go
+++ b/app/consumer-democracy/proposals_whitelisting.go
@@ -1,27 +1,35 @@
 package app
 
 import (
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	"github.com/cosmos/cosmos-sdk/x/params/types/proposal"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
+	ccvgov "github.com/cosmos/interchain-security/x/ccv/democracy/governance"
 )
 
 func IsProposalWhitelisted(content v1beta1.Content) bool {
 	switch c := content.(type) {
 	case *proposal.ParameterChangeProposal:
-		return isParamChangeWhitelisted(c.Changes)
+		return isLegacyParamChangeWhitelisted(c.Changes)
 
 	default:
 		return false
 	}
 }
 
-func isParamChangeWhitelisted(paramChanges []proposal.ParamChange) bool {
+func isLegacyParamChangeWhitelisted(paramChanges []proposal.ParamChange) bool {
 	for _, paramChange := range paramChanges {
 		_, found := LegacyWhitelistedParams[legacyParamChangeKey{Subspace: paramChange.Subspace, Key: paramChange.Key}]
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func IsParamChangeWhitelisted(keys map[ccvgov.ParamChangeKey]struct{}) bool {
+	for key := range keys {
+		_, found := WhitelistedParams[ccvgov.ParamChangeKey{MsgType: key.MsgType, Key: key.Key}]
 		if !found {
 			return false
 		}
@@ -40,34 +48,43 @@ var LegacyWhitelistedParams = map[legacyParamChangeKey]struct{}{
 	// add interchain account params(HostEnabled, AllowedMessages) once the module is added to the consumer app
 }
 
-type paramChangeKey struct {
-	MsgType, Key string
-}
-
-var WhitelistedParams = map[paramChangeKey]struct{}{
+var WhitelistedParams = map[ccvgov.ParamChangeKey]struct{}{
 	// bank
-	{MsgType: banktypes.TypeMsgUpdateParams, Key: "SendEnabled"}: {},
+	{MsgType: "/cosmos.bank.v1beta1.MsgUpdateParams", Key: "SendEnabled"}: {},
 	// governance
-	{MsgType: "cosmos.gov.v1.MsgUpdateParams", Key: "depositparams"}: {}, // min_deposit, max_deposit_period
-	{MsgType: "cosmos.gov.v1.MsgUpdateParams", Key: "votingparams"}:  {}, // voting_period
-	{MsgType: "cosmos.gov.v1.MsgUpdateParams", Key: "tallyparams"}:   {}, // quorum,threshold,veto_threshold
+	{MsgType: "/cosmos.gov.v1.MsgUpdateParams", Key: "depositparams"}: {}, // min_deposit, max_deposit_period
+	{MsgType: "/cosmos.gov.v1.MsgUpdateParams", Key: "votingparams"}:  {}, // voting_period
+	{MsgType: "/cosmos.gov.v1.MsgUpdateParams", Key: "tallyparams"}:   {}, // quorum,threshold,veto_threshold
 	// staking
-	{MsgType: stakingtypes.TypeMsgUpdateParams, Key: "UnbondingTime"}:     {},
-	{MsgType: stakingtypes.TypeMsgUpdateParams, Key: "MaxValidators"}:     {},
-	{MsgType: stakingtypes.TypeMsgUpdateParams, Key: "MaxEntries"}:        {},
-	{MsgType: stakingtypes.TypeMsgUpdateParams, Key: "HistoricalEntries"}: {},
-	{MsgType: stakingtypes.TypeMsgUpdateParams, Key: "BondDenom"}:         {},
+	{MsgType: "/cosmos.staking.v1beta1.MsgUpdateParams", Key: "UnbondingTime"}:     {},
+	{MsgType: "/cosmos.staking.v1beta1.MsgUpdateParams", Key: "MaxValidators"}:     {},
+	{MsgType: "/cosmos.staking.v1beta1.MsgUpdateParams", Key: "MaxEntries"}:        {},
+	{MsgType: "/cosmos.staking.v1beta1.MsgUpdateParams", Key: "HistoricalEntries"}: {},
+	{MsgType: "/cosmos.staking.v1beta1.MsgUpdateParams", Key: "BondDenom"}:         {},
 	// distribution
-	{MsgType: distrtypes.TypeMsgUpdateParams, Key: "communitytax"}: {},
+	{MsgType: "/cosmos.distribution.v1beta1.MsgUpdateParams", Key: "communitytax"}: {},
 	// {Subspace: distrtypes.ModuleName, Key: "baseproposerreward"}:  {},   depricated key
 	// {Subspace: distrtypes.ModuleName, Key: "bonusproposerreward"}: {},   depricated key
-	{MsgType: distrtypes.TypeMsgUpdateParams, Key: "withdrawaddrenabled"}: {},
+	{MsgType: "/cosmos.distribution.v1beta1.MsgUpdateParams", Key: "withdrawaddrenabled"}: {},
 	// mint
-	{MsgType: "cosmos.mint.v1beta1.MsgUpdateParams", Key: "MintDenom"}:           {},
-	{MsgType: "cosmos.mint.v1beta1.MsgUpdateParams", Key: "InflationRateChange"}: {},
-	{MsgType: "cosmos.mint.v1beta1.MsgUpdateParams", Key: "InflationMax"}:        {},
-	{MsgType: "cosmos.mint.v1beta1.MsgUpdateParams", Key: "InflationMin"}:        {},
-	{MsgType: "cosmos.mint.v1beta1.MsgUpdateParams", Key: "GoalBonded"}:          {},
-	{MsgType: "cosmos.mint.v1beta1.MsgUpdateParams", Key: "BlocksPerYear"}:       {},
+	{MsgType: "/cosmos.mint.v1beta1.MsgUpdateParams", Key: "MintDenom"}:           {},
+	{MsgType: "/cosmos.mint.v1beta1.MsgUpdateParams", Key: "InflationRateChange"}: {},
+	{MsgType: "/cosmos.mint.v1beta1.MsgUpdateParams", Key: "InflationMax"}:        {},
+	{MsgType: "/cosmos.mint.v1beta1.MsgUpdateParams", Key: "InflationMin"}:        {},
+	{MsgType: "/cosmos.mint.v1beta1.MsgUpdateParams", Key: "GoalBonded"}:          {},
+	{MsgType: "/cosmos.mint.v1beta1.MsgUpdateParams", Key: "BlocksPerYear"}:       {},
 	// add interchain account params(HostEnabled, AllowedMessages) once the module is added to the consumer app
+}
+
+var WhiteListModule = map[string]struct{}{
+	"/cosmos.gov.v1.MsgUpdateParams":               {},
+	"/cosmos.bank.v1beta1.MsgUpdateParams":         {},
+	"/cosmos.staking.v1beta1.MsgUpdateParams":      {},
+	"/cosmos.distribution.v1beta1.MsgUpdateParams": {},
+	"/cosmos.mint.v1beta1.MsgUpdateParams":         {},
+}
+
+func IsModuleWhiteList(typeUrl string) bool {
+	_, found := WhiteListModule[typeUrl]
+	return found
 }

--- a/app/consumer-democracy/proposals_whitelisting_test.go
+++ b/app/consumer-democracy/proposals_whitelisting_test.go
@@ -13,7 +13,7 @@ func TestDemocracyGovernanceWhitelistingKeys(t *testing.T) {
 	chain := ibctesting.NewTestChain(t, ibctesting.NewCoordinator(t, 0),
 		icstestingutils.DemocracyConsumerAppIniter, "test")
 	paramKeeper := chain.App.(*appConsumer.App).ParamsKeeper
-	for paramKey := range appConsumer.WhitelistedParams {
+	for paramKey := range appConsumer.LegacyWhitelistedParams {
 		ss, ok := paramKeeper.GetSubspace(paramKey.Subspace)
 		require.True(t, ok, "Unknown subspace %s", paramKey.Subspace)
 		hasKey := ss.Has(chain.GetContext(), []byte(paramKey.Key))

--- a/tests/integration/democracy.go
+++ b/tests/integration/democracy.go
@@ -1,8 +1,6 @@
 package integration
 
 import (
-	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
@@ -155,10 +153,9 @@ func (s *ConsumerDemocracyTestSuite) TestDemocracyGovernanceWhitelisting() {
 	bankKeeper := s.consumerApp.GetTestBankKeeper()
 	accountKeeper := s.consumerApp.GetTestAccountKeeper()
 	mintKeeper := s.consumerApp.GetTestMintKeeper()
+	authKeeper := s.consumerApp.GetTestAuthKeeper()
 	newAuthParamValue := uint64(128)
 	newMintParamValue := sdk.NewDecWithPrec(1, 1) // "0.100000000000000000"
-	allowedChange := proposaltypes.ParamChange{Subspace: minttypes.ModuleName, Key: "InflationMax", Value: fmt.Sprintf("\"%s\"", newMintParamValue)}
-	forbiddenChange := proposaltypes.ParamChange{Subspace: authtypes.ModuleName, Key: "MaxMemoCharacters", Value: fmt.Sprintf("\"%s\"", strconv.FormatUint(newAuthParamValue, 10))}
 	votingAccounts := s.consumerChain.SenderAccounts
 	bondDenom := stakingKeeper.BondDenom(s.consumerCtx())
 	depositAmount := params.MinDeposit
@@ -170,8 +167,19 @@ func (s *ConsumerDemocracyTestSuite) TestDemocracyGovernanceWhitelisting() {
 	votersOldBalances := getAccountsBalances(s.consumerCtx(), bankKeeper, bondDenom, votingAccounts)
 
 	// submit proposal with forbidden and allowed changes
-	paramChange := proposaltypes.ParameterChangeProposal{Changes: []proposaltypes.ParamChange{allowedChange, forbiddenChange}}
-	err := submitProposalWithDepositAndVote(govKeeper, s.consumerCtx(), paramChange, votingAccounts, proposer.GetAddress(), depositAmount)
+	mintParams := mintKeeper.GetParams(s.consumerCtx())
+	mintParams.InflationMax = newMintParamValue
+	msg_1 := &minttypes.MsgUpdateParams{
+		Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		Params:    mintParams,
+	}
+	authParams := authKeeper.GetParams(s.consumerCtx())
+	authParams.MaxMemoCharacters = newAuthParamValue
+	msg_2 := &authtypes.MsgUpdateParams{
+		Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+		Params:    authParams,
+	}
+	err := submitProposalWithDepositAndVote(govKeeper, s.consumerCtx(), []sdk.Msg{msg_1, msg_2}, votingAccounts, proposer.GetAddress(), depositAmount)
 	s.Assert().NoError(err)
 	// set current header time to be equal or later than voting end time in order to process proposal from active queue,
 	// once the proposal is added to the chain
@@ -193,15 +201,7 @@ func (s *ConsumerDemocracyTestSuite) TestDemocracyGovernanceWhitelisting() {
 	s.Assert().Equal(votersOldBalances, getAccountsBalances(s.consumerCtx(), bankKeeper, bondDenom, votingAccounts))
 
 	// submit proposal with allowed changes
-	mintParams := mintKeeper.GetParams(s.consumerCtx())
-	mintParams.InflationMax = newMintParamValue
-	msg := &minttypes.MsgUpdateParams{
-		Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
-		Params:    mintParams,
-	}
-	paramChange = proposaltypes.ParameterChangeProposal{Changes: []proposaltypes.ParamChange{allowedChange}}
-	// err = submitProposalWithDepositAndVote(govKeeper, s.consumerCtx(), paramChange, votingAccounts, proposer.GetAddress(), depositAmount)
-	err = test(govKeeper, s.consumerCtx(), msg, votingAccounts, proposer.GetAddress(), depositAmount)
+	err = submitProposalWithDepositAndVote(govKeeper, s.consumerCtx(), []sdk.Msg{msg_1}, votingAccounts, proposer.GetAddress(), depositAmount)
 	s.Assert().NoError(err)
 	s.consumerChain.CurrentHeader.Time = s.consumerChain.CurrentHeader.Time.Add(*params.VotingPeriod)
 	s.consumerChain.NextBlock()
@@ -215,8 +215,8 @@ func (s *ConsumerDemocracyTestSuite) TestDemocracyGovernanceWhitelisting() {
 	s.Assert().Equal(votersOldBalances, getAccountsBalances(s.consumerCtx(), bankKeeper, bondDenom, votingAccounts))
 
 	// submit proposal with forbidden changes
-	paramChange = proposaltypes.ParameterChangeProposal{Changes: []proposaltypes.ParamChange{forbiddenChange}}
-	err = submitProposalWithDepositAndVote(govKeeper, s.consumerCtx(), paramChange, votingAccounts, proposer.GetAddress(), depositAmount)
+
+	err = submitProposalWithDepositAndVote(govKeeper, s.consumerCtx(), []sdk.Msg{msg_2}, votingAccounts, proposer.GetAddress(), depositAmount)
 	s.Assert().NoError(err)
 	s.consumerChain.CurrentHeader.Time = s.consumerChain.CurrentHeader.Time.Add(*params.VotingPeriod)
 	s.consumerChain.NextBlock()
@@ -230,7 +230,7 @@ func (s *ConsumerDemocracyTestSuite) TestDemocracyGovernanceWhitelisting() {
 	s.Assert().Equal(votersOldBalances, getAccountsBalances(s.consumerCtx(), bankKeeper, bondDenom, votingAccounts))
 }
 
-func submitProposalWithDepositAndVote(govKeeper testutil.TestGovKeeper, ctx sdk.Context, paramChange proposaltypes.ParameterChangeProposal,
+func submitLegacyProposalWithDepositAndVote(govKeeper testutil.TestGovKeeper, ctx sdk.Context, paramChange proposaltypes.ParameterChangeProposal,
 	accounts []ibctesting.SenderAccount, proposer sdk.AccAddress, depositAmount sdk.Coins,
 ) error {
 	msgContent, err := govv1.NewLegacyContent(&paramChange, authtypes.NewModuleAddress(govtypes.ModuleName).String())
@@ -255,10 +255,10 @@ func submitProposalWithDepositAndVote(govKeeper testutil.TestGovKeeper, ctx sdk.
 	return nil
 }
 
-func test(govKeeper testutil.TestGovKeeper, ctx sdk.Context, msg sdk.Msg,
+func submitProposalWithDepositAndVote(govKeeper testutil.TestGovKeeper, ctx sdk.Context, msgs []sdk.Msg,
 	accounts []ibctesting.SenderAccount, proposer sdk.AccAddress, depositAmount sdk.Coins,
 ) error {
-	proposal, err := govKeeper.SubmitProposal(ctx, []sdk.Msg{msg}, "", "title", "sumary", proposer)
+	proposal, err := govKeeper.SubmitProposal(ctx, msgs, "", "title", "sumary", proposer)
 	if err != nil {
 		return err
 	}

--- a/tests/integration/democracy.go
+++ b/tests/integration/democracy.go
@@ -153,7 +153,6 @@ func (s *ConsumerDemocracyTestSuite) TestDemocracyGovernanceWhitelisting() {
 	bankKeeper := s.consumerApp.GetTestBankKeeper()
 	accountKeeper := s.consumerApp.GetTestAccountKeeper()
 	mintKeeper := s.consumerApp.GetTestMintKeeper()
-	authKeeper := s.consumerApp.GetTestAuthKeeper()
 	newAuthParamValue := uint64(128)
 	newMintParamValue := sdk.NewDecWithPrec(1, 1) // "0.100000000000000000"
 	votingAccounts := s.consumerChain.SenderAccounts
@@ -173,7 +172,7 @@ func (s *ConsumerDemocracyTestSuite) TestDemocracyGovernanceWhitelisting() {
 		Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		Params:    mintParams,
 	}
-	authParams := authKeeper.GetParams(s.consumerCtx())
+	authParams := accountKeeper.GetParams(s.consumerCtx())
 	authParams.MaxMemoCharacters = newAuthParamValue
 	msg_2 := &authtypes.MsgUpdateParams{
 		Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),

--- a/testutil/integration/interfaces.go
+++ b/testutil/integration/interfaces.go
@@ -74,6 +74,8 @@ type DemocConsumerApp interface {
 	GetTestMintKeeper() TestMintKeeper
 	// Tests a gov keeper interface with more capabilities than the expected_keepers interface
 	GetTestGovKeeper() TestGovKeeper
+	// Tests a auth keeper interface with more capabilities than the expected_keepers interface
+	GetTestAuthKeeper() TestAccountKeeper
 }
 
 //

--- a/testutil/integration/interfaces.go
+++ b/testutil/integration/interfaces.go
@@ -74,8 +74,8 @@ type DemocConsumerApp interface {
 	GetTestMintKeeper() TestMintKeeper
 	// Tests a gov keeper interface with more capabilities than the expected_keepers interface
 	GetTestGovKeeper() TestGovKeeper
-	// Tests a auth keeper interface with more capabilities than the expected_keepers interface
-	GetTestAuthKeeper() TestAccountKeeper
+
+	GetKeeperMap() map[string]interface{}
 }
 
 //

--- a/x/ccv/democracy/governance/module.go
+++ b/x/ccv/democracy/governance/module.go
@@ -92,7 +92,6 @@ func GetChangeParamsKeys(currentParams, newParams any, typeUrl string) map[Param
 	newValues := reflect.ValueOf(newParams)
 
 	for i := 0; i < currentValues.NumField(); i++ {
-		fmt.Println("hello1")
 		if !reflect.DeepEqual(currentValues.Field(i).Interface(), newValues.Field(i).Interface()) {
 			keys[ParamChangeKey{MsgType: typeUrl, Key: currentTypes.Field(i).Name}] = struct{}{}
 		}


### PR DESCRIPTION
This changes is for ics to work with how params are store differently  in sdk47 from sdk45. This change include:
- Update the test to use MsgUpdateParams
- Modify of the demo consumer app and ante struct
- Create another whiteList compare with the old one 